### PR TITLE
Make library work if vert.x or json.org classes are not on classpath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,11 +48,13 @@
             <groupId>io.vertx</groupId>
             <artifactId>vertx-core</artifactId>
             <version>${version.vertx-core}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>${version.json}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/src/main/java/de/crunc/hamcrest/json/converter/GsonConverter.java
+++ b/src/main/java/de/crunc/hamcrest/json/converter/GsonConverter.java
@@ -26,10 +26,10 @@ public enum GsonConverter {
 
         add(new StringToGsonConverter());
 
-        add(new VertxJsonObjectToGsonConverter());
-        add(new VertxJsonArrayToGsonConverter());
-        add(new JSONObjectToGsonConverter());
-        add(new JSONArrayToGsonConverter());
+        add("io.vertx.core.json.JsonObject", "de.crunc.hamcrest.json.converter.VertxJsonObjectToGsonConverter");
+        add("io.vertx.core.json.JsonArray", "de.crunc.hamcrest.json.converter.VertxJsonArrayToGsonConverter");
+        add("org.json.JSONObject", "de.crunc.hamcrest.json.converter.JSONObjectToGsonConverter");
+        add("org.json.JSONArray", "de.crunc.hamcrest.json.converter.JSONArrayToGsonConverter");
     }
 
     /**

--- a/src/main/java/de/crunc/hamcrest/json/converter/JSONArrayToGsonConverter.java
+++ b/src/main/java/de/crunc/hamcrest/json/converter/JSONArrayToGsonConverter.java
@@ -4,10 +4,9 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonPrimitive;
-import org.json.JSONArray;
 
 /**
- * Converts {@link JSONArray} to {@link JsonElement}.
+ * Converts {@link org.json.JSONArray} to {@link JsonElement}.
  *
  * @author Hauke Jaeger, hauke.jaeger@googlemail.com
  * @since 0.2

--- a/src/main/java/de/crunc/hamcrest/json/converter/JSONObjectToGsonConverter.java
+++ b/src/main/java/de/crunc/hamcrest/json/converter/JSONObjectToGsonConverter.java
@@ -4,10 +4,9 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
-import org.json.JSONObject;
 
 /**
- * Converts {@link JSONObject} to {@link JsonElement}.
+ * Converts {@link org.json.JSONObject} to {@link JsonElement}.
  *
  * @author Hauke Jaeger, hauke.jaeger@googlemail.com
  * @since 0.2


### PR DESCRIPTION
The library should be able to work also if vert.x or json.org are not on the classpath, using the dedicated converters transparently if those libraries are indeed there and avoiding classloading failures if they are not.
